### PR TITLE
upgrade google analytics call

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ That is, if you supply a Google Analytics tracking ID, the head of all pages wil
 
           bootstrap.liftmodules.GoogleAnalytics.init
 
-3. Finally, set your tracking code as the `google.analytics.id` in your Props file.  For example, add the following to `src/main/resources/production.default.props`
+3. Finally, set your tracking code as the `google.tag.manager.id` in your Props file.  For example, add the following to `src/main/resources/production.default.props`
 
-         google.analytics.id=UA-XXXXXXXX-X
+         google.tag.manager.id=GTM-XXXXXX
 
-    ...obviously replacing `XXXXXXX-X` with the code Google issued you with.  Be sure to start your Lift app with `-Drun.mode=production` flag (or set the value of google.analytics.id in your dev props file).
+    ...obviously replacing `XXXXXX` with the code Google issued you with.  Be sure to start your Lift app with `-Drun.mode=production` flag (or set the value of google.tag.manager.id in your dev props file).
 
 
 ## Conditional behaviour

--- a/build.sbt
+++ b/build.sbt
@@ -5,9 +5,9 @@ name := "google-analytics"
 
 organization := "net.liftmodules"
 
-version := "1.1.0-SNAPSHOT"
+version := "1.1.1-SNAPSHOT"
 
-liftVersion := "3.1.0-RC1"
+liftVersion := "3.2.0"
 
 liftEdition := liftVersion.value.replaceAllLiterally("-SNAPSHOT", "").split('.').take(2).mkString(".")
 

--- a/src/main/scala/net/liftmodules/googleanalytics/Async.scala
+++ b/src/main/scala/net/liftmodules/googleanalytics/Async.scala
@@ -19,16 +19,29 @@ import scala.xml.Unparsed
 
 object Async {
 
-  def headJs(id: String) = <script type="text/javascript">
-    var _gaq = _gaq || [];
-    _gaq.push(['_setAccount', '{Unparsed(id)}']);
-    _gaq.push(['_trackPageview']);
-    (function() {{
-      var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;
-      ga.src = ('https:' == document.location.protocol ? 'https://ssl' : 'http://www') + '.google-analytics.com/ga.js';
-      var s = document.getElementsByTagName('script')[0];
-      s.parentNode.insertBefore(ga, s);
-    }})();
+  def headJs(id: String) = {
+    val tagManagerContent: String =
+      "(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':\n"+
+        "new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],\n"+
+        "j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=\n"+
+        "'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);\n"+
+        "})(window,document,'script','dataLayer','"+id+"');"
+
+    <script>
+      <!-- Google Tag Manager -->
+      { tagManagerContent }
+      <!-- End Google Tag Manager -->
     </script>
+  }
+
+  def bodyScript(id: String) = {
+    val url = s"https://www.googletagmanager.com/ns.html?id=$id"
+
+    <noscript>
+      <iframe src={url} height="0" width="0"
+              style="display:none;visibility:hidden">
+      </iframe>
+    </noscript>
+  }
 
 }


### PR DESCRIPTION
Upgrade Google Analytics to the last way, based on Google instructions:

*  ga.js is deprecated , replaced by  analytics.js 
*  analytics.js  is deprecated, replaced by google tag manager.

i this upgrade we are using the call focus to GTM (recommended by google).

